### PR TITLE
Adjust CI after branch renames

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: test
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The branch was renamed but I never updated the CI triggers. Let's get that done so that pull-requests get randomtested.