### PR TITLE
Overrides *bug to allow testing errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           rm choicescript/web/mygame/scenes/*
           cp cslib/scenes/* choicescript/web/mygame/scenes
+          cp cslib/mygame.js choicescript/web/mygame
       - name: Run randomtest
         run: |
           cd choicescript

--- a/mygame.js
+++ b/mygame.js
@@ -1,0 +1,28 @@
+nav = new SceneNavigator(["startup"]);
+stats = {};
+
+// We modify Scene.prototype.bug to make *bug 'catchable'.
+// If the stat cslib_catch_bug is set to true, in case of a bug a function
+// will simply return. The error message will be available in cslib_bug_message.
+// Make sure cslib_catch_bug is immediately reset to false.
+//
+// Example usage:
+//
+//    *set cslib_catch_bug true
+//    *gosub_scene cslib_... ... ...
+//    *set cslib_catch_bug false
+//    *gosub test_finish "Expected message" cslib_bug_message
+
+Scene.prototype.bug = function scene_bug(message) {
+  if (message) {
+    message = "Bug: " + this.replaceVariables(message);
+  } else {
+    message = "Bug";
+  }
+  if (this.stats.cslib_catch_bug) {
+    this.stats.cslib_bug_message = message;
+    this.return();
+  } else {
+    throw new Error(this.lineMsg() + message);
+  }
+}

--- a/scenes/startup.txt
+++ b/scenes/startup.txt
@@ -44,38 +44,6 @@
 
 *set implicit_control_flow true
 
-
-
-*comment We modify Scene.prototype.bug to make *bug 'catchable'.
-*comment If the stat cslib_catch_bug is set to true, in case of a bug a function
-*comment will simply return. The error message will be available in cslib_bug_message.
-*comment Make sure cslib_catch_bug is immediately reset to false.
-
-*comment Example usage:
-
-*comment    *set cslib_catch_bug true
-*comment    *gosub_scene cslib_... ... ...
-*comment    *set cslib_catch_bug false
-*comment    *gosub test_finish "Expected message" cslib_bug_message
-
-*comment The updated code:
-
-*comment   Scene.prototype.bug = function scene_bug(message) {
-*comment     if (message) {
-*comment       message = "Bug: " + this.replaceVariables(message);
-*comment     } else {
-*comment       message = "Bug";
-*comment     }
-*comment     if (this.stats.cslib_catch_bug) {
-*comment       this.stats.cslib_bug_message = message;
-*comment       this.return();
-*comment     } else {
-*comment       throw new Error(this.lineMsg() + message);
-*comment     }
-*comment   }
-
-*script Scene.prototype.bug = function scene_bug(message) {if (message) {message = "Bug: " + this.replaceVariables(message);} else {message = "Bug";} if (this.stats.cslib_catch_bug) {this.stats.cslib_bug_message = message;  this.return();} else {throw new Error(this.lineMsg() + message);}}
-
 *if (automatic_testing)
 	*comment automatic 'test all' for CI, quicktest etc.
 	*gosub_scene _test_entry test_all_modules

--- a/scenes/startup.txt
+++ b/scenes/startup.txt
@@ -40,7 +40,41 @@
 
 *create str_buffer ""
 
+*create cslib_catch_bug false
+
 *set implicit_control_flow true
+
+
+
+*comment We modify Scene.prototype.bug to make *bug 'catchable'.
+*comment If the stat cslib_catch_bug is set to true, in case of a bug a function
+*comment will simply return. The error message will be available in cslib_bug_message.
+*comment Make sure cslib_catch_bug is immediately reset to false.
+
+*comment Example usage:
+
+*comment    *set cslib_catch_bug true
+*comment    *gosub_scene cslib_... ... ...
+*comment    *set cslib_catch_bug false
+*comment    *gosub test_finish "Expected message" cslib_bug_message
+
+*comment The updated code:
+
+*comment   Scene.prototype.bug = function scene_bug(message) {
+*comment     if (message) {
+*comment       message = "Bug: " + this.replaceVariables(message);
+*comment     } else {
+*comment       message = "Bug";
+*comment     }
+*comment     if (this.stats.cslib_catch_bug) {
+*comment       this.stats.cslib_bug_message = message;
+*comment       this.return();
+*comment     } else {
+*comment       throw new Error(this.lineMsg() + message);
+*comment     }
+*comment   }
+
+*script Scene.prototype.bug = function scene_bug(message) {if (message) {message = "Bug: " + this.replaceVariables(message);} else {message = "Bug";} if (this.stats.cslib_catch_bug) {this.stats.cslib_bug_message = message;  this.return();} else {throw new Error(this.lineMsg() + message);}}
 
 *if (automatic_testing)
 	*comment automatic 'test all' for CI, quicktest etc.

--- a/scenes/test_string.txt
+++ b/scenes/test_string.txt
@@ -62,6 +62,20 @@
 *gosub test_finish result_expected cslib_ret
 
 
+*comment :::::: INDEX tests ::::::
+*gosub test_start "INDEX #1"
+*temp result_expected 3
+*gosub_scene cslib_string index "ABCDEF" "C"
+*gosub test_finish result_expected cslib_ret
+
+*gosub test_start "INDEX #2"
+*set cslib_catch_bug true
+*temp result_expected "Bug: p_char should be a single character, not \"\""
+*gosub_scene cslib_string index "ABCDEF" ""
+*set cslib_catch_bug false
+*gosub test_finish result_expected cslib_bug_message
+
+
 *comment :::::: LOWERCASE tests ::::::
 *gosub test_start "LOWERCASE #1"
 *temp result_expected "lowercase"


### PR DESCRIPTION
This change redefines *bug (in mygame.js) to check for the value of cslib_catch_bug. If that's true, *bug won't fail but simply *return, and it will store the *bug message in a global variable (cslib_bug_message). Users can decide to 'catch' *bug by setting cslib_catch_bug to true, running their code and testing the bug message.