### PR TITLE
Function extract_tokens

### DIFF
--- a/scenes/cslib_string.txt
+++ b/scenes/cslib_string.txt
@@ -329,7 +329,7 @@
 *comment 			p_separator(string): a character upon which to split the string.
 *comment			p_array(string): the array name/reference (prefix)
 *comment 		returns:
-*comment 			(integer): the number of tokens in the string.
+*comment 			(number): the number of tokens in the string.
 *label extract_tokens
 *params p_source p_separator p_array
 

--- a/scenes/cslib_string.txt
+++ b/scenes/cslib_string.txt
@@ -314,3 +314,61 @@
 		*goto consists_of_char_list_loop
 	*set cslib_ret false
 *return
+
+
+*comment EXTRACT_TOKENS
+*comment ------------------------------
+*comment Split a given string using a separator.
+*comment The tokens are stored in a given array, up to its max.
+*comment ------------------------------
+*comment 		params:
+*comment 			p_source: the string to be split.
+*comment 			p_separator: one character to be used as a separator.
+*comment			p_array(string): the array name/reference (prefix)
+*comment 		returns:
+*comment 			(boolean): the number of tokens in the string.
+*label extract_tokens
+*params p_source p_separator p_array
+
+*set cslib_ret 0
+*set {p_array & "_count"} 0
+
+*temp source_len length(p_source)
+*temp array_max {p_array & "_max"}
+
+*if p_separator = ""
+	*bug Separator should not be empty in extract_tokens.
+*if length(p_separator) > 1
+	*bug Separator should be a single char in extract_tokens.
+
+*comment Clean up the destination array.
+*temp array_idx 1
+*label loop_clean_array
+*set {(p_array & "_") & array_idx} ""
+*set array_idx +1
+*if array_idx <= array_max
+	*goto loop_clean_array
+
+*temp source_idx 1
+*set array_idx 1
+*temp target (p_array & "_") & array_idx
+
+*if source_len = 0
+	*return
+
+*label source_loop
+*temp next_char p_source#source_idx
+*if next_char = p_separator
+	*set array_idx +1
+*else
+	*if array_idx <= array_max
+		*set target (p_array & "_") & array_idx
+		*set {target} &next_char
+		*set {p_array & "_count"} array_idx
+
+*set source_idx +1
+*if source_idx <= source_len
+	*goto source_loop
+
+*set cslib_ret array_idx
+*return

--- a/scenes/cslib_string.txt
+++ b/scenes/cslib_string.txt
@@ -318,56 +318,59 @@
 *comment EXTRACT_TOKENS
 *comment ------------------------------
 *comment Split a given string using a separator.
-*comment The tokens are stored in a given array, up to its max.
+*comment The tokens are stored in a given array, up to its _max.
+*comment The array's _count will be updated with the number of valid items.
+*comment Note that, if the array is too small to contain all values,
+*comment only _max will be stored, _count will be equal _max and
+*comment cslib_ret will have the full token count.
 *comment ------------------------------
 *comment 		params:
-*comment 			p_source: the string to be split.
-*comment 			p_separator: one character to be used as a separator.
+*comment 			p_source(string): the string to be split.
+*comment 			p_separator(string): a character upon which to split the string.
 *comment			p_array(string): the array name/reference (prefix)
 *comment 		returns:
-*comment 			(boolean): the number of tokens in the string.
+*comment 			(integer): the number of tokens in the string.
 *label extract_tokens
 *params p_source p_separator p_array
 
-*set cslib_ret 0
-*set {p_array & "_count"} 0
+*if p_separator = ""
+	*bug cslib_string.extract_tokens: Separator should not be empty in extract_tokens.
+*if length(p_separator) > 1
+	*bug cslib_string.extract_tokens: Separator should be a single char in extract_tokens, not: '${p_separator}'.
 
 *temp source_len length(p_source)
 *temp array_max {p_array & "_max"}
+*set {p_array & "_count"} 0
 
-*if p_separator = ""
-	*bug Separator should not be empty in extract_tokens.
-*if length(p_separator) > 1
-	*bug Separator should be a single char in extract_tokens.
+*if source_len = 0
+	*set cslib_ret 0
+	*return
 
 *comment Clean up the destination array.
 *temp array_idx 1
-*label loop_clean_array
+*label _loop_clean_array
 *set {(p_array & "_") & array_idx} ""
 *set array_idx +1
 *if array_idx <= array_max
-	*goto loop_clean_array
+	*goto _loop_clean_array
 
 *temp source_idx 1
 *set array_idx 1
 *temp target (p_array & "_") & array_idx
 
-*if source_len = 0
-	*return
-
-*label source_loop
+*label _source_loop
 *temp next_char p_source#source_idx
 *if next_char = p_separator
 	*set array_idx +1
+	*set target (p_array & "_") & array_idx
 *else
 	*if array_idx <= array_max
-		*set target (p_array & "_") & array_idx
 		*set {target} &next_char
 		*set {p_array & "_count"} array_idx
 
 *set source_idx +1
 *if source_idx <= source_len
-	*goto source_loop
+	*goto _source_loop
 
 *set cslib_ret array_idx
 *return

--- a/scenes/cslib_string.txt
+++ b/scenes/cslib_string.txt
@@ -346,23 +346,18 @@
 	*set cslib_ret 0
 	*return
 
-*comment Clean up the destination array.
-*temp array_idx 1
-*label _loop_clean_array
-*set {(p_array & "_") & array_idx} ""
-*set array_idx +1
-*if array_idx <= array_max
-	*goto _loop_clean_array
-
 *temp source_idx 1
-*set array_idx 1
+*temp array_idx 1
 *temp target (p_array & "_") & array_idx
+*set {target} ""
 
 *label _source_loop
 *temp next_char p_source#source_idx
 *if next_char = p_separator
 	*set array_idx +1
 	*set target (p_array & "_") & array_idx
+	*if array_idx <= array_max
+		*set {target} ""
 *else
 	*if array_idx <= array_max
 		*set {target} &next_char

--- a/scenes/startup.txt
+++ b/scenes/startup.txt
@@ -42,7 +42,21 @@
 
 *create cslib_catch_bug false
 
+*comment ARRAY USED AS RESULT FROM TOKENIZATION
+*create tokens_1 ""
+*create tokens_2 ""
+*create tokens_3 ""
+*create tokens_4 ""
+*create tokens_5 ""
+*comment The max number of entries (storage size).
+*create tokens_max 5
+*comment The number of valid entries.
+*create tokens_count 0
+
 *set implicit_control_flow true
+*looplimit 0
+
+HERE
 
 *if (automatic_testing)
 	*comment automatic 'test all' for CI, quicktest etc.

--- a/scenes/startup.txt
+++ b/scenes/startup.txt
@@ -54,9 +54,6 @@
 *create tokens_count 0
 
 *set implicit_control_flow true
-*looplimit 0
-
-HERE
 
 *if (automatic_testing)
 	*comment automatic 'test all' for CI, quicktest etc.

--- a/scenes/test_string.txt
+++ b/scenes/test_string.txt
@@ -139,44 +139,134 @@
 *gosub test_finish result_expected cslib_ret
 
 
-*comment :::::: EXTRACT TOKEN tests ::::::
-*comment *gosub test_start "EXTRACT_TOKEN #1"
-*comment *temp result_expected "VAL=TRUE"
-*comment *set str_buffer "VAL=TRUE|VAL=FALSE|VAL=TRUE"
-*comment *gosub_scene cslib_string extract_token "str_buffer" "|"
-*comment *gosub test_finish result_expected cslib_ret
+:::::: EXTRACT TOKENS tests ::::::
+*comment Extract 3 tokens into an array of 5.
+*gosub test_start "EXTRACT_TOKENS #1"
+*set str_buffer "VAL=TRUE|VAL=FALSE|VAL=TRUE"
+*gosub_scene cslib_string extract_tokens str_buffer "|" "tokens"
+*gosub test_finish 3 cslib_ret
+*gosub test_finish "VAL=TRUE" tokens_1
+*gosub test_finish "VAL=FALSE" tokens_2
+*gosub test_finish "VAL=TRUE" tokens_3
+*comment The rest of the array is still empty.
+*gosub test_finish "" tokens_4
+*gosub test_finish "" tokens_5
+*gosub test_finish 5 tokens_max
+*gosub test_finish 3 tokens_count
 
-*comment *gosub test_start "EXTRACT_TOKEN #2"
-*comment *temp result_expected "VAL=FALSE|VAL=TRUE"
-*comment *set str_buffer "VAL=TRUE|VAL=FALSE|VAL=TRUE"
-*comment *gosub_scene cslib_string extract_token "str_buffer" "|"
-*comment *gosub test_finish result_expected str_buffer
+*comment Extract 2 tokens into an array of 5. Remaining entries are reset.
+*gosub test_start "EXTRACT_TOKENS #2"
+*set str_buffer "VAL=HERE|VAL=THERE"
+*gosub_scene cslib_string extract_tokens str_buffer "|" "tokens"
+*gosub test_finish 2 cslib_ret
+*gosub test_finish "VAL=HERE" tokens_1
+*gosub test_finish "VAL=THERE" tokens_2
+*comment The rest of the array is wiped clean.
+*gosub test_finish "" tokens_3
+*gosub test_finish "" tokens_4
+*gosub test_finish "" tokens_5
+*gosub test_finish 5 tokens_max
+*gosub test_finish 2 tokens_count
 
-*comment *gosub test_start "EXTRACT_TOKEN #3"
-*comment *temp result_expected "VAL=TRUE, VAL=FALSE, VAL=TRUE"
-*comment *temp result_actual ""
-*comment *set str_buffer "VAL=TRUE|VAL=FALSE|VAL=TRUE"
-*comment *label test_extact_token_3_loop
-*comment *gosub_scene cslib_string extract_token "str_buffer" "|"
-*comment *if cslib_ret != ""
-	*comment *set result_actual &("@{(result_actual = \"\") |, }${cslib_ret}")
-	*comment *goto test_extact_token_3_loop
-*comment *gosub test_finish result_expected result_actual
+*comment Extract 6 tokens into an array of 5 (only 5 are copied).
+*gosub test_start "EXTRACT_TOKENS #3"
+*set str_buffer "A|B|C|D|E|F"
+*gosub_scene cslib_string extract_tokens str_buffer "|" "tokens"
+*comment There are actually 6 values, but only 5 are used.
+*comment The user may check for this condition.
+*gosub test_finish 6 cslib_ret
+*gosub test_finish "A" tokens_1
+*gosub test_finish "B" tokens_2
+*gosub test_finish "C" tokens_3
+*gosub test_finish "D" tokens_4
+*gosub test_finish "E" tokens_5
+*gosub test_finish 5 tokens_max
+*gosub test_finish 5 tokens_count
 
+*comment Empty source.
+*gosub test_start "EXTRACT_TOKENS #4"
+*set str_buffer ""
+*gosub_scene cslib_string extract_tokens str_buffer "|" "tokens"
+*gosub test_finish 0 cslib_ret
+*gosub test_finish "" tokens_1
+*gosub test_finish "" tokens_2
+*gosub test_finish "" tokens_3
+*gosub test_finish "" tokens_4
+*gosub test_finish "" tokens_5
+*gosub test_finish 5 tokens_max
+*gosub test_finish 0 tokens_count
+
+*comment Only one token.
+*gosub test_start "EXTRACT_TOKENS #5"
+*set str_buffer "HI"
+*gosub_scene cslib_string extract_tokens str_buffer "|" "tokens"
+*gosub test_finish 1 cslib_ret
+*gosub test_finish "HI" tokens_1
+*gosub test_finish "" tokens_2
+*gosub test_finish "" tokens_3
+*gosub test_finish "" tokens_4
+*gosub test_finish "" tokens_5
+*gosub test_finish 5 tokens_max
+*gosub test_finish 1 tokens_count
+
+*comment Empty tokens.
+*gosub test_start "EXTRACT_TOKENS #6"
+*set str_buffer "|A||C|"
+*gosub_scene cslib_string extract_tokens str_buffer "|" "tokens"
+*gosub test_finish 5 cslib_ret
+*gosub test_finish "" tokens_1
+*gosub test_finish "A" tokens_2
+*gosub test_finish "" tokens_3
+*gosub test_finish "C" tokens_4
+*gosub test_finish "" tokens_5
+*gosub test_finish 5 tokens_max
+*gosub test_finish 4 tokens_count
+
+*comment Missing separator.
+*gosub test_start "EXTRACT TOKENS #7"
+*temp result_expected "Bug: Separator should not be empty in extract_tokens."
+*set str_buffer "|A||C|"
+
+*set cslib_catch_bug true
+*gosub_scene cslib_string extract_tokens str_buffer "" "tokens"
+*set cslib_catch_bug false
+*gosub test_finish cslib_bug_message result_expected
+
+*comment Multiple separators.
+*gosub test_start "EXTRACT TOKENS #8"
+*temp result_expected "Bug: Separator should be a single char in extract_tokens."
+*set str_buffer "|A||C|"
+
+*set cslib_catch_bug true
+*gosub_scene cslib_string extract_tokens str_buffer "|-()" "tokens"
+*set cslib_catch_bug false
+*gosub test_finish cslib_bug_message result_expected
+
+*comment Empty source.
+*gosub test_start "EXTRACT_TOKENS #9"
+*set str_buffer ""
+*gosub_scene cslib_string extract_tokens str_buffer "|" "tokens"
+*gosub test_finish 0 cslib_ret
+*gosub test_finish "" tokens_1
+*gosub test_finish "" tokens_2
+*gosub test_finish "" tokens_3
+*gosub test_finish "" tokens_4
+*gosub test_finish "" tokens_5
+*gosub test_finish 5 tokens_max
+*gosub test_finish 0 tokens_count
 
 *set cslib_ret "${tests_passed}|${test_count}"
 *return
 
-
 *comment :::::: UTILITY routines ::::::
 *label test_start
 *params p_test_name
-*set test_count + 1
 *set {log_buffer} &"TEST ${p_test_name}: "
 *return
 
 *label test_finish
 *params p_result_expected p_result_actual
+*set test_count + 1
 *temp result (p_result_expected = p_result_actual)
 *set {log_buffer} &"@{result PASS|FAIL}[n/]"
 *if result

--- a/scenes/test_string.txt
+++ b/scenes/test_string.txt
@@ -144,28 +144,28 @@
 *gosub test_start "EXTRACT_TOKENS #1"
 *set str_buffer "VAL=TRUE|VAL=FALSE|VAL=TRUE"
 *gosub_scene cslib_string extract_tokens str_buffer "|" "tokens"
-*gosub test_finish 3 cslib_ret
-*gosub test_finish "VAL=TRUE" tokens_1
-*gosub test_finish "VAL=FALSE" tokens_2
-*gosub test_finish "VAL=TRUE" tokens_3
+*gosub test_assert_equal 3 cslib_ret
+*gosub test_assert_equal "VAL=TRUE" tokens_1
+*gosub test_assert_equal "VAL=FALSE" tokens_2
+*gosub test_assert_equal "VAL=TRUE" tokens_3
 *comment The rest of the array is still empty.
-*gosub test_finish "" tokens_4
-*gosub test_finish "" tokens_5
-*gosub test_finish 5 tokens_max
+*gosub test_assert_equal "" tokens_4
+*gosub test_assert_equal "" tokens_5
+*gosub test_assert_equal 5 tokens_max
 *gosub test_finish 3 tokens_count
 
 *comment Extract 2 tokens into an array of 5. Remaining entries are reset.
 *gosub test_start "EXTRACT_TOKENS #2"
 *set str_buffer "VAL=HERE|VAL=THERE"
 *gosub_scene cslib_string extract_tokens str_buffer "|" "tokens"
-*gosub test_finish 2 cslib_ret
-*gosub test_finish "VAL=HERE" tokens_1
-*gosub test_finish "VAL=THERE" tokens_2
+*gosub test_assert_equal 2 cslib_ret
+*gosub test_assert_equal "VAL=HERE" tokens_1
+*gosub test_assert_equal "VAL=THERE" tokens_2
 *comment The rest of the array is wiped clean.
-*gosub test_finish "" tokens_3
-*gosub test_finish "" tokens_4
-*gosub test_finish "" tokens_5
-*gosub test_finish 5 tokens_max
+*gosub test_assert_equal "" tokens_3
+*gosub test_assert_equal "" tokens_4
+*gosub test_assert_equal "" tokens_5
+*gosub test_assert_equal 5 tokens_max
 *gosub test_finish 2 tokens_count
 
 *comment Extract 6 tokens into an array of 5 (only 5 are copied).
@@ -174,57 +174,57 @@
 *gosub_scene cslib_string extract_tokens str_buffer "|" "tokens"
 *comment There are actually 6 values, but only 5 are used.
 *comment The user may check for this condition.
-*gosub test_finish 6 cslib_ret
-*gosub test_finish "A" tokens_1
-*gosub test_finish "B" tokens_2
-*gosub test_finish "C" tokens_3
-*gosub test_finish "D" tokens_4
-*gosub test_finish "E" tokens_5
-*gosub test_finish 5 tokens_max
+*gosub test_assert_equal 6 cslib_ret
+*gosub test_assert_equal "A" tokens_1
+*gosub test_assert_equal "B" tokens_2
+*gosub test_assert_equal "C" tokens_3
+*gosub test_assert_equal "D" tokens_4
+*gosub test_assert_equal "E" tokens_5
+*gosub test_assert_equal 5 tokens_max
 *gosub test_finish 5 tokens_count
 
-*comment Empty source.
+*comment Empty source. The array is unchanged.
 *gosub test_start "EXTRACT_TOKENS #4"
 *set str_buffer ""
 *gosub_scene cslib_string extract_tokens str_buffer "|" "tokens"
-*gosub test_finish 0 cslib_ret
-*gosub test_finish "" tokens_1
-*gosub test_finish "" tokens_2
-*gosub test_finish "" tokens_3
-*gosub test_finish "" tokens_4
-*gosub test_finish "" tokens_5
-*gosub test_finish 5 tokens_max
+*gosub test_assert_equal 0 cslib_ret
+*gosub test_assert_equal "A" tokens_1
+*gosub test_assert_equal "B" tokens_2
+*gosub test_assert_equal "C" tokens_3
+*gosub test_assert_equal "D" tokens_4
+*gosub test_assert_equal "E" tokens_5
+*gosub test_assert_equal 5 tokens_max
 *gosub test_finish 0 tokens_count
 
 *comment Only one token.
 *gosub test_start "EXTRACT_TOKENS #5"
 *set str_buffer "HI"
 *gosub_scene cslib_string extract_tokens str_buffer "|" "tokens"
-*gosub test_finish 1 cslib_ret
-*gosub test_finish "HI" tokens_1
-*gosub test_finish "" tokens_2
-*gosub test_finish "" tokens_3
-*gosub test_finish "" tokens_4
-*gosub test_finish "" tokens_5
-*gosub test_finish 5 tokens_max
+*gosub test_assert_equal 1 cslib_ret
+*gosub test_assert_equal "HI" tokens_1
+*gosub test_assert_equal "" tokens_2
+*gosub test_assert_equal "" tokens_3
+*gosub test_assert_equal "" tokens_4
+*gosub test_assert_equal "" tokens_5
+*gosub test_assert_equal 5 tokens_max
 *gosub test_finish 1 tokens_count
 
 *comment Empty tokens.
 *gosub test_start "EXTRACT_TOKENS #6"
 *set str_buffer "|A||C|"
 *gosub_scene cslib_string extract_tokens str_buffer "|" "tokens"
-*gosub test_finish 5 cslib_ret
-*gosub test_finish "" tokens_1
-*gosub test_finish "A" tokens_2
-*gosub test_finish "" tokens_3
-*gosub test_finish "C" tokens_4
-*gosub test_finish "" tokens_5
-*gosub test_finish 5 tokens_max
+*gosub test_assert_equal 5 cslib_ret
+*gosub test_assert_equal "" tokens_1
+*gosub test_assert_equal "A" tokens_2
+*gosub test_assert_equal "" tokens_3
+*gosub test_assert_equal "C" tokens_4
+*gosub test_assert_equal "" tokens_5
+*gosub test_assert_equal 5 tokens_max
 *gosub test_finish 4 tokens_count
 
 *comment Missing separator.
 *gosub test_start "EXTRACT TOKENS #7"
-*temp result_expected "Bug: Separator should not be empty in extract_tokens."
+*temp result_expected "Bug: cslib_string.extract_tokens: Separator should not be empty in extract_tokens."
 *set str_buffer "|A||C|"
 
 *set cslib_catch_bug true
@@ -234,7 +234,7 @@
 
 *comment Multiple separators.
 *gosub test_start "EXTRACT TOKENS #8"
-*temp result_expected "Bug: Separator should be a single char in extract_tokens."
+*temp result_expected "Bug: cslib_string.extract_tokens: Separator should be a single char in extract_tokens, not: '|-()'."
 *set str_buffer "|A||C|"
 
 *set cslib_catch_bug true
@@ -242,41 +242,19 @@
 *set cslib_catch_bug false
 *gosub test_finish cslib_bug_message result_expected
 
-*comment Empty source.
-*gosub test_start "EXTRACT_TOKENS #9"
-*set str_buffer ""
-*gosub_scene cslib_string extract_tokens str_buffer "|" "tokens"
-*gosub test_finish 0 cslib_ret
-*gosub test_finish "" tokens_1
-*gosub test_finish "" tokens_2
-*gosub test_finish "" tokens_3
-*gosub test_finish "" tokens_4
-*gosub test_finish "" tokens_5
-*gosub test_finish 5 tokens_max
-*gosub test_finish 0 tokens_count
-
 *set cslib_ret "${tests_passed}|${test_count}"
 *return
 
 *comment :::::: UTILITY routines ::::::
 *label test_start
 *params p_test_name
-<<<<<<< HEAD
-=======
 *temp test_result true
 *set test_count + 1
->>>>>>> origin/main
 *set {log_buffer} &"TEST ${p_test_name}: "
 *return
 
 *label test_assert_equal
 *params p_result_expected p_result_actual
-<<<<<<< HEAD
-*set test_count + 1
-*temp result (p_result_expected = p_result_actual)
-*set {log_buffer} &"@{result PASS|FAIL}[n/]"
-*if result
-=======
 *gosub test_assert (p_result_expected = p_result_actual) "=> Expected - ${p_result_expected}[n/]=> Received - ${p_result_actual}[n/]"
 *return
 
@@ -293,6 +271,5 @@
 	*gosub test_assert_equal param_1 param_2
 *set {log_buffer} &"@{test_result PASS|FAIL}[n/]"
 *if test_result
->>>>>>> origin/main
 	*set tests_passed + 1
 *return

--- a/scenes/test_string.txt
+++ b/scenes/test_string.txt
@@ -154,17 +154,13 @@
 *gosub test_assert_equal 5 tokens_max
 *gosub test_finish 3 tokens_count
 
-*comment Extract 2 tokens into an array of 5. Remaining entries are reset.
+*comment Extract 2 tokens into an array of 5. Remaining entries are undefined.
 *gosub test_start "EXTRACT_TOKENS #2"
 *set str_buffer "VAL=HERE|VAL=THERE"
 *gosub_scene cslib_string extract_tokens str_buffer "|" "tokens"
 *gosub test_assert_equal 2 cslib_ret
 *gosub test_assert_equal "VAL=HERE" tokens_1
 *gosub test_assert_equal "VAL=THERE" tokens_2
-*comment The rest of the array is wiped clean.
-*gosub test_assert_equal "" tokens_3
-*gosub test_assert_equal "" tokens_4
-*gosub test_assert_equal "" tokens_5
 *gosub test_assert_equal 5 tokens_max
 *gosub test_finish 2 tokens_count
 
@@ -183,16 +179,11 @@
 *gosub test_assert_equal 5 tokens_max
 *gosub test_finish 5 tokens_count
 
-*comment Empty source. The array is unchanged.
+*comment Empty source. The array is not manipulated.
 *gosub test_start "EXTRACT_TOKENS #4"
 *set str_buffer ""
 *gosub_scene cslib_string extract_tokens str_buffer "|" "tokens"
 *gosub test_assert_equal 0 cslib_ret
-*gosub test_assert_equal "A" tokens_1
-*gosub test_assert_equal "B" tokens_2
-*gosub test_assert_equal "C" tokens_3
-*gosub test_assert_equal "D" tokens_4
-*gosub test_assert_equal "E" tokens_5
 *gosub test_assert_equal 5 tokens_max
 *gosub test_finish 0 tokens_count
 
@@ -202,10 +193,6 @@
 *gosub_scene cslib_string extract_tokens str_buffer "|" "tokens"
 *gosub test_assert_equal 1 cslib_ret
 *gosub test_assert_equal "HI" tokens_1
-*gosub test_assert_equal "" tokens_2
-*gosub test_assert_equal "" tokens_3
-*gosub test_assert_equal "" tokens_4
-*gosub test_assert_equal "" tokens_5
 *gosub test_assert_equal 5 tokens_max
 *gosub test_finish 1 tokens_count
 


### PR DESCRIPTION
New extract_tokens function in cslib_string.

This will break up a string (using a single-char separator) into an array, up to {array}_max values. The number of tokens is returned as cslib_ret. The number of values actually copied is available in {array}_count, so it can be passed directly to cslib_menu and similar.