### PR TITLE
Min/max for stats (passed by name)

### DIFF
--- a/scenes/cslib_number.txt
+++ b/scenes/cslib_number.txt
@@ -120,12 +120,12 @@
 
 *comment MAX_STAT
 *comment ------------------------------
-*comment Returns the largest of a set of given stats.
+*comment Returns the variable name of the largest of a set of given stats.
 *comment ------------------------------
 *comment 	params:
-*comment		param_n(string): a stat (passed by name)
+*comment		param_n(string): the name of a stat variable
 *comment	returns: 
-*comment		(string): the stat with the largest value
+*comment		(string): the variable name of the stat with the largest value
 *label max_stat
 *params
 *gosub_scene cslib_assert greater_or_equal_to param_count 2
@@ -143,12 +143,12 @@
 
 *comment MIN_STAT
 *comment ------------------------------
-*comment Returns the smallest of a set of given stats.
+*comment Returns the variable name of the smallest of a set of given stats.
 *comment ------------------------------
 *comment 	params:
-*comment		param_n(string): a stat (passed by name)
+*comment		param_n(string): the name of a stat variable
 *comment	returns: 
-*comment		(string): the stat with the smallest value
+*comment		(string): the variable name of the stat with the smallest value
 *label min_stat
 *params
 *gosub_scene cslib_assert greater_or_equal_to param_count 2

--- a/scenes/cslib_number.txt
+++ b/scenes/cslib_number.txt
@@ -104,7 +104,7 @@
 *comment	returns: 
 *comment		(number): the smallest number
 *label min
-*params arr_ref
+*params
 *gosub_scene cslib_assert greater_or_equal_to param_count 2
 *temp current param[1]
 *temp n 2
@@ -116,6 +116,52 @@
 	*set current param[n]
 *set n + 1
 *goto min_loop
+
+
+*comment MAX_STAT
+*comment ------------------------------
+*comment Returns the largest of a set of given stats.
+*comment ------------------------------
+*comment 	params:
+*comment		param_n(string): a stat (passed by name)
+*comment	returns: 
+*comment		(string): the stat with the largest value
+*label max_stat
+*params
+*gosub_scene cslib_assert greater_or_equal_to param_count 2
+*temp current param[1]
+*temp n 2
+*label max_stat_loop
+*if (n > param_count)
+	*set cslib_ret current
+	*return
+*if ({param[n]} > {current})
+	*set current param[n]
+*set n + 1
+*goto max_stat_loop
+
+
+*comment MIN_STAT
+*comment ------------------------------
+*comment Returns the smallest of a set of given stats.
+*comment ------------------------------
+*comment 	params:
+*comment		param_n(string): a stat (passed by name)
+*comment	returns: 
+*comment		(string): the stat with the smallest value
+*label min_stat
+*params
+*gosub_scene cslib_assert greater_or_equal_to param_count 2
+*temp current param[1]
+*temp n 2
+*label min_stat_loop
+*if (n > param_count)
+	*set cslib_ret current
+	*return
+*if ({param[n]} < {current})
+	*set current param[n]
+*set n + 1
+*goto min_stat_loop
 
 
 *label _char_is_number

--- a/scenes/startup.txt
+++ b/scenes/startup.txt
@@ -42,6 +42,11 @@
 
 *create cslib_catch_bug false
 
+*comment Some stats for min/max
+*create test_stat_strength 100
+*create test_stat_charisma 50
+*create test_stat_wisdom 10
+
 *set implicit_control_flow true
 
 *if (automatic_testing)

--- a/scenes/startup.txt
+++ b/scenes/startup.txt
@@ -43,9 +43,9 @@
 *create cslib_catch_bug false
 
 *comment Some stats for min/max
-*create test_stat_strength 100
-*create test_stat_charisma 50
-*create test_stat_wisdom 10
+*create test_stat_strength 0
+*create test_stat_charisma 0
+*create test_stat_wisdom 0
 
 *set implicit_control_flow true
 

--- a/scenes/test_number.txt
+++ b/scenes/test_number.txt
@@ -27,6 +27,9 @@
 
 *comment :::::: MAX_STAT tests ::::::
 *gosub test_start "MAX_STAT #1"
+*set test_stat_strength 100
+*set test_stat_charisma 50
+*set test_stat_wisdom 10
 *temp result_expected "test_stat_strength"
 *gosub_scene cslib_number max_stat "test_stat_strength" "test_stat_charisma" "test_stat_wisdom"
 *gosub test_finish result_expected cslib_ret

--- a/scenes/test_number.txt
+++ b/scenes/test_number.txt
@@ -25,6 +25,20 @@
 *gosub test_finish result_expected cslib_ret
 
 
+*comment :::::: MAX_STAT tests ::::::
+*gosub test_start "MAX_STAT #1"
+*temp result_expected "test_stat_strength"
+*gosub_scene cslib_number max_stat "test_stat_strength" "test_stat_charisma" "test_stat_wisdom"
+*gosub test_finish result_expected cslib_ret
+
+
+*comment :::::: MIN_STAT tests ::::::
+*gosub test_start "MIN_STAT #1"
+*temp result_expected "test_stat_wisdom"
+*gosub_scene cslib_number min_stat "test_stat_strength" "test_stat_charisma" "test_stat_wisdom"
+*gosub test_finish result_expected cslib_ret
+
+
 *comment :::::: IS_NUMBER tests ::::::
 *gosub test_start "IS_NUMBER #1"
 *temp result_expected true


### PR DESCRIPTION
Introduces a modified version of min/max that compares stats (passed by 'reference', ie. with their name as a string).

Note that min, max, min_stat and max_stat share most of the code. We may want to merge them into a common function and pass a flag to drive the comparison.