### PR TITLE
Add implicit_control_flow to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@ The idea is to provide a community built (and supported) collection of routines,
 
 ### Installation
 - Copy the module files (the ones that start with `cslib_`) to your game folder, together with your scene files.
-
 - Create a global variable called `cslib_ret` to hold return values.
+- Create (or set) `implicit_control_flow` to **true**.
 
 ```choicescript
 __startup.txt__
 
+*create implicit_control_flow true
 *create cslib_ret 0
 ```
 


### PR DESCRIPTION
A lot of CSLIB is wrote in a way that assumes
implicit_control_flow is enabled, in order to
keep the code leaner/more concise.

Users may get away with calling the occasional
function without enabling it, but they'll eventually
need to do so.