### PR TITLE
Enhance changelog format and mention breaking array change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 # CSLIB Changelog
 
+This changelog only covers end-user facing changes (i.e. user-affecting changes to the cslib modules themselves).<br>
+It does not cover changes to tests or examples (please please refer to the git log for those).
+
 ## [0.2.0] (TBD)
 
-- Adds cslib_object (@StephenXHart)
+### Breaking Changes
+
+- Modules now use \*temp_array (requiring ChoiceScript > [b72ea67](https://github.com/dfabulich/choicescript/commit/b72ea67bd25da079dd769ebe0b2a1df21f55c6bd))
+
+### Contributions
+
+- [@StephenXHart](https://github.com/StephenXHart): cslib_object module ([PR #3382](https://github.com/ChoicescriptIDE/cslib/pull/41))
 
 ## [0.1.0] (20.05.2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,6 @@ It does not cover changes to tests or examples (please refer to the git log for 
 
 ### Contributions
 
-- [@StephenXHart](https://github.com/StephenXHart): cslib_object module ([PR #3382](https://github.com/ChoicescriptIDE/cslib/pull/41))
+- [@StephenXHart](https://github.com/StephenXHart): cslib_object module ([PR #41](https://github.com/ChoicescriptIDE/cslib/pull/41))
 
 ## [0.1.0] (20.05.2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CSLIB Changelog
 
 This changelog only covers end-user facing changes (i.e. user-affecting changes to the cslib modules themselves).<br>
-It does not cover changes to tests or examples (please please refer to the git log for those).
+It does not cover changes to tests or examples (please refer to the git log for those).
 
 ## [0.2.0] (TBD)
 


### PR DESCRIPTION
Improves the format of CHANGELOG.md and makes mention of the new usage of \*temp_array which is a breaking change (if people are on older versions of ChoiceScript).